### PR TITLE
Fix #10

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    datacat: "https://github.com/richardc/puppet-datacat.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     git: "https://github.com/puppetlabs/puppetlabs-git.git"
     python: "https://github.com/stankevich/puppet-python.git"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ Upcoming Release 0.4
 - update metadata
 - improve systemd support
 - add $port parameter (from #18)
-- implement #16, #17 and #19:
+- implement #10, #16, #17 and #19:
+  - add kallithea_version fact
   - add $rcextensions parameter
   - add $service_provider parameter
   - add $whoosh_cronjob parameter

--- a/README.md
+++ b/README.md
@@ -65,17 +65,14 @@ Put the classes, types, and resources for customizing, configuring, and doing th
 * [`kallithea`](#class-kallithea)
 * [`kallithea::seed_db`](#class-kallitheaseed_db)
 
-#### Private Classes
-
-* `kallithea::config`
-* `kallithea::install`
-* `kallithea::params`
-* `kallithea::service`
-
-### Defines
+### Public Defines
 
 * [`kallithea::package`](#define-kallitheapackage)
 * [`kallithea::ini_setting`](#define-inisetting)
+
+### Facts
+
+* `kallithea_version`
 
 #### Class `kallithea`
 

--- a/lib/facter/kallithea.rb
+++ b/lib/facter/kallithea.rb
@@ -1,0 +1,19 @@
+require 'yaml'
+
+settings_file = '/etc/kallithea.yml'
+
+if File.exists? settings_file
+  data = YAML.load_file(settings_file)
+  if data['metadata_version'] == '1'
+    venv = data['default']['venv']
+    pip = "#{venv}/bin/pip"
+    if File.exists? pip
+      Facter.add('kallithea_version') do
+        setcode do
+          Facter::Core::Execution.exec("#{venv}/bin/pip show kallithea").match(/^Version: (.*)/)[1]
+        end
+      end
+    end
+  end
+end
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,7 @@ class kallithea (
 
   ##################################################
 
+  class { '::kallithea::settings_store': } ->
   class { '::kallithea::install': } ->
   class { '::kallithea::config': } ~>
   class { '::kallithea::service': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -88,6 +88,10 @@ class kallithea::install (
     ],
   }
 
+  kallithea::stored_setting { 'venv':
+    data => { 'default' => { 'venv' => $venv } },
+  }
+
   # Normally, the `PasteScript` package is a `setup_requires`-dependency of
   # `kallithea`. This has the problem, that when we are behind a corporate proxy and using an
   # internal package index, pip still tries to contact PyPi for installing

--- a/manifests/settings_store.pp
+++ b/manifests/settings_store.pp
@@ -1,0 +1,18 @@
+# == Class kallithea::settings_store
+#
+# This class will setup a yaml file for persisting some parameters the
+# kallithea class has been called with. It is meant to be read by custom
+# kallithea facts.
+
+class kallithea::settings_store {
+  $file = '/etc/kallithea.yml'
+
+  datacat { $file:
+    template => "${module_name}/settings_store.yml.erb",
+  }
+
+  kallithea::stored_setting { 'settings_store version':
+    data => { 'metadata_version' => '1' },
+  }
+}
+

--- a/manifests/stored_setting.pp
+++ b/manifests/stored_setting.pp
@@ -1,0 +1,16 @@
+# == Define kallithea::stored_setting
+#
+# This defined type is used to store $data in the yaml file created by the
+# settings_store class. The $data's of different defines get (deeply) merged.
+
+define kallithea::stored_setting (
+  $data,
+) {
+  include kallithea::settings_store
+
+  datacat_fragment { $title:
+    target => $::kallithea::settings_store::file,
+    data   => $data
+  }
+}
+

--- a/metadata.json
+++ b/metadata.json
@@ -36,6 +36,10 @@
     {
       "name": "stankevich/python",
       "version_requirement": ">=1.9.0 <2.0.0"
+    },
+    {
+      "name": "richardc/datacat",
+      "version_requirement": ">=0.2.0 <1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/kallithea_spec.rb
+++ b/spec/acceptance/kallithea_spec.rb
@@ -40,11 +40,6 @@ describe 'kallithea class' do
       it { should be_file }
     end
 
-    describe command('facter -p kallithea_version') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should_not eq '' }
-    end
-
     describe service('kallithea') do
       it { is_expected.to be_running }
       # for some reason, the following fails on acceptance testing,
@@ -87,10 +82,10 @@ describe 'kallithea class' do
       }
     end
 
-    describe command('facter -p kallithea_version') do
+    describe command('/srv/kallithea/venv/bin/pip show kallithea') do
       its(:exit_status) { should eq 0 }
       if kallithea_version
-        its(:stdout) { should eq kallithea_version }
+        its(:stdout) { should match /^Version: #{kallithea_version}$/ }
       end
     end
   end
@@ -161,9 +156,8 @@ describe 'kallithea class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe command('facter -p kallithea_version') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should eq '0.2.1' }
+    describe command('/srv/kallithea/venv/bin/pip show kallithea') do
+      its(:stdout) { should match /^Version: 0.2.1$/ }
     end
 
   end

--- a/spec/acceptance/kallithea_spec.rb
+++ b/spec/acceptance/kallithea_spec.rb
@@ -36,6 +36,15 @@ describe 'kallithea class' do
       it { should be_owned_by 'kallithea' }
     end
 
+    describe file('/etc/kallithea.yml') do
+      it { should be_file }
+    end
+
+    describe command('facter -p kallithea_version') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should_not eq '' }
+    end
+
     describe service('kallithea') do
       it { is_expected.to be_running }
       # for some reason, the following fails on acceptance testing,
@@ -78,10 +87,10 @@ describe 'kallithea class' do
       }
     end
 
-    describe command('/srv/kallithea/venv/bin/pip show kallithea') do
+    describe command('facter -p kallithea_version') do
       its(:exit_status) { should eq 0 }
       if kallithea_version
-        its(:stdout) { should match /^Version: #{kallithea_version}$/ }
+        its(:stdout) { should eq kallithea_version }
       end
     end
   end
@@ -152,8 +161,9 @@ describe 'kallithea class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe command('/srv/kallithea/venv/bin/pip show kallithea') do
-      its(:stdout) { should match /^Version: 0.2.1$/ }
+    describe command('facter -p kallithea_version') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should eq '0.2.1' }
     end
 
   end

--- a/spec/classes/settings_store_spec.rb
+++ b/spec/classes/settings_store_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'kallithea::settings_store' do
+  it { should contain_datacat('/etc/kallithea.yml') }
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,6 +17,7 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'kallithea')
+    on hosts, puppet('module', 'install', 'richardc/datacat'), { :acceptable_exit_codes => [0,1] }
     on hosts, puppet('module', 'install', 'puppetlabs/inifile'), { :acceptable_exit_codes => [0,1] }
     on hosts, puppet('module', 'install', 'puppetlabs/stdlib'), { :acceptable_exit_codes => [0,1] }
     on hosts, puppet('module', 'install', 'stankevich/python'), { :acceptable_exit_codes => [0,1] }

--- a/templates/settings_store.yml.erb
+++ b/templates/settings_store.yml.erb
@@ -1,0 +1,2 @@
+# This file is managed by Puppet, your changes will be overwritten!
+<%= @data.to_yaml %>


### PR DESCRIPTION
A prototype for implementing #10. It still has some issues:
- The new `kallithea_version` fact is not tested (beaker doesn't do it, because pluginsync is disabled on puppet apply - maybe we could 'sync it by hand' during acceptance tests?
- Management of `/etc/kallithea.yml` is not idempotent - needs to be sorted somehow...
